### PR TITLE
prototype rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tinyrick"
 description = "a freeform Rust build system"
 version = "0.0.14"
-edition = "2021"
+edition = "2024"
 authors = ["Andrew Pennebaker <andrew.pennebaker@gmail.com>"]
 license = "BSD-2-Clause"
 homepage = "https://github.com/mcandre/tinyrick"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tinyrick"
 description = "a freeform Rust build system"
 version = "0.0.14"
-edition = "2024"
+edition = "2021"
 authors = ["Andrew Pennebaker <andrew.pennebaker@gmail.com>"]
 license = "BSD-2-Clause"
 homepage = "https://github.com/mcandre/tinyrick"

--- a/README.md
+++ b/README.md
@@ -67,20 +67,20 @@ fn banner() {
 }
 
 fn test() {
-    tinyrick::exec!("cargo", &["test"]);
+    tinyrick::exec("cargo", &["test"]);
 }
 
 fn build() {
     tinyrick::deps(test);
-    tinyrick::exec!("cargo", &["build", "--release"]);
+    tinyrick::exec("cargo", &["build", "--release"]);
 }
 
 fn publish() {
-    tinyrick::exec!("cargo", &["publish"]);
+    tinyrick::exec("cargo", &["publish"]);
 }
 
 fn clean() {
-    tinyrick::exec!("cargo", &["clean"]);
+    tinyrick::exec("cargo", &["clean"]);
 }
 
 fn main() {
@@ -138,7 +138,7 @@ Where are my pants? Let's break down the code so far:
 
 * `fn name() { ... }` declares a task named `name`.
 * `deps(requirement)` caches a dependency on task `requirement`.
-* `exec!(...)` spawns raw shell command processes.
+* `exec(...)` spawns raw shell command processes.
 * `VERBOSE=1` enables command string emission during processing.
 * `phony!(...)` disables dependency caching for some tasks.
 * `wubba_lubba_dub_dub!(default; ...)` exposes a `default` task and some other tasks to the tinyrick command line.

--- a/example/tinyrick.rs
+++ b/example/tinyrick.rs
@@ -4,12 +4,12 @@ extern crate tinyrick;
 
 /// Run clippy
 fn clippy() {
-    tinyrick::exec!("cargo", &["clippy"]);
+    tinyrick::exec("cargo", &["clippy"]);
 }
 
 /// Generate documentation
 fn doc() {
-    tinyrick::exec!("cargo", &["doc"]);
+    tinyrick::exec("cargo", &["doc"]);
 }
 
 /// Static code validation
@@ -21,26 +21,26 @@ fn lint() {
 /// Lint, and then install artifacts
 fn install() {
     tinyrick::deps(lint);
-    tinyrick::exec!("cargo", &["install", "--force", "--path", "."]);
+    tinyrick::exec("cargo", &["install", "--force", "--path", "."]);
 }
 
 /// Uninstall artifacts
 fn uninstall() {
-    tinyrick::exec!("cargo", &["uninstall"]);
+    tinyrick::exec("cargo", &["uninstall"]);
 }
 
 /// Lint, and then run unit tests
 fn unit_test() {
     tinyrick::deps(lint);
-    tinyrick::exec!("cargo", &["test"]);
+    tinyrick::exec("cargo", &["test"]);
 }
 
 /// Lint, and then run integration tests
 fn integration_test() {
     tinyrick::deps(install);
 
-    assert!(tinyrick::exec_stdout_utf8!("add_two", &["-n", "2"]) == "4\n");
-    assert!(!tinyrick::exec_status!("add_two").success());
+    assert!(tinyrick::exec_stdout_utf8("add_two", &["-n", "2"]) == "4\n");
+    assert!(!tinyrick::exec_status("add_two").success());
 }
 
 /// Lint, and then run tests
@@ -52,13 +52,13 @@ fn test() {
 /// Lint, test, and build debug binaries
 fn build_debug() {
     tinyrick::deps(test);
-    tinyrick::exec!("cargo", &["build"]);
+    tinyrick::exec("cargo", &["build"]);
 }
 
 /// Lint, test, and build release binaries
 fn build_release() {
     tinyrick::deps(test);
-    tinyrick::exec!("cargo", &["build", "--release"]);
+    tinyrick::exec("cargo", &["build", "--release"]);
 }
 
 /// Lint, test, and then build binaries
@@ -74,12 +74,12 @@ fn banner() {
 
 /// Publish to crate repository
 fn publish() {
-    tinyrick::exec!("cargo", &["publish"]);
+    tinyrick::exec("cargo", &["publish"]);
 }
 
 /// Run cargo clean
 fn clean_cargo() {
-    tinyrick::exec!("cargo", &["clean"]);
+    tinyrick::exec("cargo", &["clean"]);
 }
 
 /// Clean workspaces

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,9 +88,7 @@ macro_rules! exec_mut {
         let args: &[&str] = &[];
         tinyrick::exec_mut_with_arguments!($p, args)
     }};
-    ($p : expr, $a : expr) => {{
-        tinyrick::exec_mut_with_arguments!($p, $a)
-    }};
+    ($p : expr, $a : expr) => {{ tinyrick::exec_mut_with_arguments!($p, $a) }};
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -100,12 +98,8 @@ macro_rules! exec_mut {
 /// Panics if the command exits with a failure status.
 #[macro_export]
 macro_rules! exec_output {
-    ($p : expr) => {{
-        tinyrick::exec_mut!($p).output().unwrap()
-    }};
-    ($p : expr, $a : expr) => {{
-        tinyrick::exec_mut!($p, $a).output().unwrap()
-    }};
+    ($p : expr) => {{ tinyrick::exec_mut!($p).output().unwrap() }};
+    ($p : expr, $a : expr) => {{ tinyrick::exec_mut!($p, $a).output().unwrap() }};
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -115,12 +109,8 @@ macro_rules! exec_output {
 /// Panics if the command exits with a failure status.
 #[macro_export]
 macro_rules! exec_stdout {
-    ($p : expr) => {{
-        tinyrick::exec_output!($p).stdout
-    }};
-    ($p : expr, $a : expr) => {{
-        tinyrick::exec_output!($p, $a).stdout
-    }};
+    ($p : expr) => {{ tinyrick::exec_output!($p).stdout }};
+    ($p : expr, $a : expr) => {{ tinyrick::exec_output!($p, $a).stdout }};
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -130,12 +120,8 @@ macro_rules! exec_stdout {
 /// Panics if the command exits with a failure status.
 #[macro_export]
 macro_rules! exec_stderr {
-    ($p : expr) => {{
-        tinyrick::exec_output!($p).stderr
-    }};
-    ($p : expr, $a : expr) => {{
-        tinyrick::exec_output!($p, $a).stderr
-    }};
+    ($p : expr) => {{ tinyrick::exec_output!($p).stderr }};
+    ($p : expr, $a : expr) => {{ tinyrick::exec_output!($p, $a).stderr }};
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -145,12 +131,8 @@ macro_rules! exec_stderr {
 /// Panics if the command exits with a failure status.
 #[macro_export]
 macro_rules! exec_stdout_utf8 {
-    ($p : expr) => {{
-        String::from_utf8(tinyrick::exec_stdout!($p)).unwrap()
-    }};
-    ($p : expr, $a : expr) => {{
-        String::from_utf8(tinyrick::exec_stdout!($p, $a)).unwrap()
-    }};
+    ($p : expr) => {{ String::from_utf8(tinyrick::exec_stdout!($p)).unwrap() }};
+    ($p : expr, $a : expr) => {{ String::from_utf8(tinyrick::exec_stdout!($p, $a)).unwrap() }};
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -160,12 +142,8 @@ macro_rules! exec_stdout_utf8 {
 /// Panics if the command exits with a failure status.
 #[macro_export]
 macro_rules! exec_stderr_utf8 {
-    ($p : expr) => {{
-        String::from_utf8(tinyrick::exec_stderr!($p)).unwrap()
-    }};
-    ($p : expr, $a : expr) => {{
-        String::from_utf8(tinyrick::exec_stderr!($p, $a)).unwrap()
-    }};
+    ($p : expr) => {{ String::from_utf8(tinyrick::exec_stderr!($p)).unwrap() }};
+    ($p : expr, $a : expr) => {{ String::from_utf8(tinyrick::exec_stderr!($p, $a)).unwrap() }};
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -175,12 +153,8 @@ macro_rules! exec_stderr_utf8 {
 /// Panics if the command could not run to completion.
 #[macro_export]
 macro_rules! exec_status {
-    ($p : expr) => {{
-        tinyrick::exec_mut!($p).status().unwrap()
-    }};
-    ($p : expr, $a : expr) => {{
-        tinyrick::exec_mut!($p, $a).status().unwrap()
-    }};
+    ($p : expr) => {{ tinyrick::exec_mut!($p).status().unwrap() }};
+    ($p : expr, $a : expr) => {{ tinyrick::exec_mut!($p, $a).status().unwrap() }};
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -192,9 +166,7 @@ macro_rules! exec {
     ($p : expr) => {{
         assert!(tinyrick::exec_status!($p).success());
     }};
-    ($p : expr, $a : expr) => {{
-        assert!(tinyrick::exec_status!($p, $a).success())
-    }};
+    ($p : expr, $a : expr) => {{ assert!(tinyrick::exec_status!($p, $a).success()) }};
 }
 
 /// Show registered tasks

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 extern crate lazy_static;
 
 use std::collections::HashMap;
+use std::env::var;
+use std::process::Command;
 use std::sync::Mutex;
 
 /// Cargo toggle
@@ -64,18 +66,12 @@ macro_rules! phony {
 ///
 /// Executes the given program with the given arguments.
 /// Returns the command object.
-#[macro_export]
-macro_rules! exec_mut_with_arguments {
-    ($p : expr, $a : expr) => {{
-        use std::env::var;
-        use std::process::Command;
+pub fn exec_mut_with_arguments<'a>(name : &'astr, args : &'a[&str]) -> &'a mut Command {
+    if var(VERBOSE_ENVIRONMENT_NAME).is_ok() {
+        println!("{} {}", name, args.join(" "));
+    }
 
-        if var(tinyrick::VERBOSE_ENVIRONMENT_NAME).is_ok() {
-            println!("{} {}", $p, $a.join(" "));
-        }
-
-        Command::new($p).args($a)
-    }};
+    Command::new(name).args(args)
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -86,10 +82,10 @@ macro_rules! exec_mut_with_arguments {
 macro_rules! exec_mut {
     ($p : expr) => {{
         let args: &[&str] = &[];
-        tinyrick::exec_mut_with_arguments!($p, args)
+        tinyrick::exec_mut_with_arguments($p, args)
     }};
     ($p : expr, $a : expr) => {
-        tinyrick::exec_mut_with_arguments!($p, $a)
+        tinyrick::exec_mut_with_arguments($p, $a)
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,9 @@ macro_rules! exec_mut {
         let args: &[&str] = &[];
         tinyrick::exec_mut_with_arguments!($p, args)
     }};
-    ($p : expr, $a : expr) => {{ tinyrick::exec_mut_with_arguments!($p, $a) }};
+    ($p : expr, $a : expr) => {
+        tinyrick::exec_mut_with_arguments!($p, $a)
+    };
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -98,8 +100,12 @@ macro_rules! exec_mut {
 /// Panics if the command exits with a failure status.
 #[macro_export]
 macro_rules! exec_output {
-    ($p : expr) => {{ tinyrick::exec_mut!($p).output().unwrap() }};
-    ($p : expr, $a : expr) => {{ tinyrick::exec_mut!($p, $a).output().unwrap() }};
+    ($p : expr) => {
+        tinyrick::exec_mut!($p).output().unwrap()
+    };
+    ($p : expr, $a : expr) => {
+        tinyrick::exec_mut!($p, $a).output().unwrap()
+    };
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -109,8 +115,12 @@ macro_rules! exec_output {
 /// Panics if the command exits with a failure status.
 #[macro_export]
 macro_rules! exec_stdout {
-    ($p : expr) => {{ tinyrick::exec_output!($p).stdout }};
-    ($p : expr, $a : expr) => {{ tinyrick::exec_output!($p, $a).stdout }};
+    ($p : expr) => {
+        tinyrick::exec_output!($p).stdout
+    };
+    ($p : expr, $a : expr) => {
+        tinyrick::exec_output!($p, $a).stdout
+    };
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -120,8 +130,12 @@ macro_rules! exec_stdout {
 /// Panics if the command exits with a failure status.
 #[macro_export]
 macro_rules! exec_stderr {
-    ($p : expr) => {{ tinyrick::exec_output!($p).stderr }};
-    ($p : expr, $a : expr) => {{ tinyrick::exec_output!($p, $a).stderr }};
+    ($p : expr) => {
+        tinyrick::exec_output!($p).stderr
+    };
+    ($p : expr, $a : expr) => {
+        tinyrick::exec_output!($p, $a).stderr
+    };
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -131,8 +145,12 @@ macro_rules! exec_stderr {
 /// Panics if the command exits with a failure status.
 #[macro_export]
 macro_rules! exec_stdout_utf8 {
-    ($p : expr) => {{ String::from_utf8(tinyrick::exec_stdout!($p)).unwrap() }};
-    ($p : expr, $a : expr) => {{ String::from_utf8(tinyrick::exec_stdout!($p, $a)).unwrap() }};
+    ($p : expr) => {
+        String::from_utf8(tinyrick::exec_stdout!($p)).unwrap()
+    };
+    ($p : expr, $a : expr) => {
+        String::from_utf8(tinyrick::exec_stdout!($p, $a)).unwrap()
+    };
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -142,8 +160,12 @@ macro_rules! exec_stdout_utf8 {
 /// Panics if the command exits with a failure status.
 #[macro_export]
 macro_rules! exec_stderr_utf8 {
-    ($p : expr) => {{ String::from_utf8(tinyrick::exec_stderr!($p)).unwrap() }};
-    ($p : expr, $a : expr) => {{ String::from_utf8(tinyrick::exec_stderr!($p, $a)).unwrap() }};
+    ($p : expr) => {
+        String::from_utf8(tinyrick::exec_stderr!($p)).unwrap()
+    };
+    ($p : expr, $a : expr) => {
+        String::from_utf8(tinyrick::exec_stderr!($p, $a)).unwrap()
+    };
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -153,8 +175,12 @@ macro_rules! exec_stderr_utf8 {
 /// Panics if the command could not run to completion.
 #[macro_export]
 macro_rules! exec_status {
-    ($p : expr) => {{ tinyrick::exec_mut!($p).status().unwrap() }};
-    ($p : expr, $a : expr) => {{ tinyrick::exec_mut!($p, $a).status().unwrap() }};
+    ($p : expr) => {
+        tinyrick::exec_mut!($p).status().unwrap()
+    };
+    ($p : expr, $a : expr) => {
+        tinyrick::exec_mut!($p, $a).status().unwrap()
+    };
 }
 
 /// Hey genius, avoid executing commands whenever possible! Look for Rust libraries instead.
@@ -163,10 +189,12 @@ macro_rules! exec_status {
 /// Panics if the command exits with a failure status.
 #[macro_export]
 macro_rules! exec {
-    ($p : expr) => {{
+    ($p : expr) => {
         assert!(tinyrick::exec_status!($p).success());
-    }};
-    ($p : expr, $a : expr) => {{ assert!(tinyrick::exec_status!($p, $a).success()) }};
+    };
+    ($p : expr, $a : expr) => {
+        assert!(tinyrick::exec_status!($p, $a).success())
+    };
 }
 
 /// Show registered tasks
@@ -199,29 +227,31 @@ macro_rules! list_tasks {
 #[macro_export]
 macro_rules! wubba_lubba_dub_dub {
     ($d : expr ; $($t : expr),*) => {
-        use std::env;
-        use std::process;
+        {
+            use std::env;
+            use std::process;
 
-        let arguments: Vec<String> = env::args().collect();
+            let arguments: Vec<String> = env::args().collect();
 
-        let task_names: Vec<&str> = arguments
-            .iter()
-            .skip(1)
-            .map(String::as_str)
-            .collect();
+            let task_names: Vec<&str> = arguments
+                .iter()
+                .skip(1)
+                .map(String::as_str)
+                .collect();
 
-        if task_names.is_empty() {
-            $d();
-            process::exit(0);
-        }
+            if task_names.is_empty() {
+                $d();
+                process::exit(0);
+            }
 
-        for task_name in task_names {
-            match task_name {
-                "-l" => tinyrick::list_tasks!($d $(, $t)*),
-                "--list" => tinyrick::list_tasks!($d $(, $t)*),
-                stringify!($d) => $d(),
-                $(stringify!($t) => $t(),)*
-                _ => panic!("Unknown task {}", task_name)
+            for task_name in task_names {
+                match task_name {
+                    "-l" => tinyrick::list_tasks!($d $(, $t)*),
+                    "--list" => tinyrick::list_tasks!($d $(, $t)*),
+                    stringify!($d) => $d(),
+                    $(stringify!($t) => $t(),)*
+                    _ => panic!("Unknown task {}", task_name)
+                }
             }
         }
     };

--- a/src/tinyrick.rs
+++ b/src/tinyrick.rs
@@ -4,7 +4,7 @@ extern crate die;
 extern crate getopts;
 extern crate tinyrick;
 
-use die::{die, Die};
+use die::{Die, die};
 use std::env;
 use std::path;
 

--- a/src/tinyrick.rs
+++ b/src/tinyrick.rs
@@ -37,7 +37,7 @@ fn main() {
     let list_tasks: bool = optmatches.opt_present("l");
     let tasks: Vec<String> = optmatches.free;
 
-    tinyrick::exec!(
+    tinyrick::exec(
         "cargo",
         &[
             "build",
@@ -59,9 +59,9 @@ fn main() {
     let rick_path: &str = rick_pathbuf.to_str().unwrap();
 
     if list_tasks {
-        tinyrick::exec!(rick_path, &["-l"]);
+        tinyrick::exec(rick_path, &["-l"]);
         die!(0);
     }
 
-    tinyrick::exec!(rick_path, tasks);
+    tinyrick::exec(rick_path, tasks);
 }

--- a/src/tinyrick.rs
+++ b/src/tinyrick.rs
@@ -4,7 +4,7 @@ extern crate die;
 extern crate getopts;
 extern crate tinyrick;
 
-use die::{Die, die};
+use die::{die, Die};
 use std::env;
 use std::path;
 


### PR DESCRIPTION
work in progress; strange new lifetime compile errors trigger for basic macros when adopting rust edition 2024:

```console
$ cargo install --force --path .
error[E0716]: temporary value dropped while borrowed
  --> src/tinyrick.rs:40:5
   |
40 | /     tinyrick::exec!(
41 | |         "cargo",
42 | |         &[
43 | |             "build",
...  |
49 | |     );
   | |     ^
   | |     |
   | |     creates a temporary value which is freed while still in use
   | |_____temporary value is freed at the end of this statement
   |       borrow later used by call
   |
   = note: consider using a `let` binding to create a longer lived value
   = note: this error originates in the macro `tinyrick::exec_mut_with_arguments` which comes from the expansion of the macro `tinyrick::exec` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0716]: temporary value dropped while borrowed
  --> src/tinyrick.rs:66:5
   |
66 |     tinyrick::exec!(rick_path, tasks);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     creates a temporary value which is freed while still in use
   |     temporary value is freed at the end of this statement
   |     borrow later used by call
   |
   = note: consider using a `let` binding to create a longer lived value
   = note: this error originates in the macro `tinyrick::exec_mut_with_arguments` which comes from the expansion of the macro `tinyrick::exec` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0716]: temporary value dropped while borrowed
  --> src/tinyrick.rs:62:9
   |
62 |         tinyrick::exec!(rick_path, &["-l"]);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |         |
   |         creates a temporary value which is freed while still in use
   |         temporary value is freed at the end of this statement
   |         borrow later used by call
   |
   = note: consider using a `let` binding to create a longer lived value
   = note: this error originates in the macro `tinyrick::exec_mut_with_arguments` which comes from the expansion of the macro `tinyrick::exec` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0716`.
error: could not compile `tinyrick` (bin "tinyrick") due to 3 previous errors
error: failed to compile `tinyrick v0.0.14 (/Users/andrew/go/src/github.com/mcandre/tinyrick)`, intermediate artifacts can be found at `/Users/andrew/go/src/github.com/mcandre/tinyrick/target`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```